### PR TITLE
feat: handler object with `nextIf404` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,58 @@ import { devApi } from 'vite-plugin-dev-api';
 
 export default defineConfig({
   plugins: [
-    devApi(async (request: Request, next: () => never) => {
+    devApi(async (request: Request, ctx: { next: () => never }) => {
       if (request.url === '/api/data') {
         return new Response(JSON.stringify({ message: 'Hello, world!' }), {
           headers: { 'Content-Type': 'application/json' }
         });
       }
-      return next(); // Proceed to the next handler if not matched
+      return ctx.next(); // Proceed to the next handler if not matched
     });
+  ],
+});
+```
+
+You can configure handler behavior:
+
+```typescript
+import { defineConfig } from 'vite';
+import { devApi } from 'vite-plugin-dev-api';
+
+export default defineConfig({
+  plugins: [
+    devApi({
+      fetch: async (request, ctx) => {
+        if (request.url === '/api/data') {
+          return new Response(JSON.stringify({ message: 'Hello, world!' }), {
+            headers: { 'Content-Type': 'application/json' }
+          });
+        }
+        return new Response('Not Found', { status: 404 });
+      },
+      nextIf404: true, // Call next() if the response status is 404
+    });
+  ],
+});
+```
+
+And you can use [Hono](https://hono.dev/) for the handler:
+
+```typescript
+import { Hono } from 'hono';
+import { defineConfig } from 'vite';
+import { devApi } from 'vite-plugin-dev-api';
+
+const hono = new Hono();
+hono.get('/api/data', (c) => {
+  return c.json({ message: 'Hello, world!' });
+});
+
+export default defineConfig({
+  plugins: [
+    devApi(hono),
+    // or
+    devApi({ fetch: hono.fetch, nextIf404: true }),
   ],
 });
 ```

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.1.2",
 		"@types/node": "^24.1.0",
+		"hono": "^4.8.9",
 		"tsdown": "^0.13.0",
 		"typescript": "^5.8.3",
 		"vite": "^7.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@types/node':
         specifier: ^24.1.0
         version: 24.1.0
+      hono:
+        specifier: ^4.8.9
+        version: 4.8.9
       tsdown:
         specifier: ^0.13.0
         version: 0.13.0(@typescript/native-preview@7.0.0-dev.20250726.1)(typescript@5.8.3)
@@ -660,6 +663,10 @@ packages:
 
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+
+  hono@4.8.9:
+    resolution: {integrity: sha512-ERIxkXMRhUxGV7nS/Af52+j2KL60B1eg+k6cPtgzrGughS+espS9KQ7QO0SMnevtmRlBfAcN0mf1jKtO6j/doA==}
+    engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -1371,6 +1378,8 @@ snapshots:
   get-tsconfig@4.10.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  hono@4.8.9: {}
 
   hookable@5.5.3: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,8 +25,8 @@ const nextSymbol = Symbol("next");
 const handlerContext: HandlerContext = {
 	next: () => {
 		throw nextSymbol;
-	}
-}
+	},
+};
 
 export function devApi(...handlers: (Handler | HandlerObject)[]): Plugin {
 	return {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced request handler flexibility, allowing handlers to be passed as objects with advanced options such as conditional delegation based on response status (e.g., continue to the next handler on 404 responses).
  * Added support for integrating with the Hono web framework as a handler.

* **Documentation**
  * Updated usage examples in the README to reflect the new handler interface and demonstrate advanced configurations, including Hono integration.

* **Tests**
  * Expanded test coverage to include scenarios for the new handler options and Hono integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->